### PR TITLE
Make Gt serializable

### DIFF
--- a/src/fields/fq12.rs
+++ b/src/fields/fq12.rs
@@ -23,7 +23,7 @@ fn frobenius_coeffs_c1(power: usize) -> Fq2 {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 #[repr(C)]
 pub struct Fq12 {
     c0: Fq6,

--- a/src/fields/fq6.rs
+++ b/src/fields/fq6.rs
@@ -39,7 +39,7 @@ fn frobenius_coeffs_c2(n: usize) -> Fq2 {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 #[repr(C)]
 pub struct Fq6 {
     pub c0: Fq2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,19 @@ impl Gt {
     pub fn inverse(&self) -> Self { Gt(self.0.inverse().unwrap()) }
 }
 
+pub trait SerializableGt:
+        rustc_serialize::Encodable +
+        rustc_serialize::Decodable +
+        'static +
+        Copy +
+        Clone +
+        PartialEq +
+        Eq
+{
+}
+
+impl SerializableGt for Gt {}
+
 impl Mul<Gt> for Gt {
     type Output = Gt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl Mul<Fr> for G2 {
     fn mul(self, other: Fr) -> G2 { G2(self.0 * other.0) }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, RustcDecodable, RustcEncodable)]
 #[repr(C)]
 pub struct Gt(fields::Fq12);
 


### PR DESCRIPTION
Hi,

We needed Gt to be serializabe. This approach might not be the cleanest solution as I am still a rust newbie, but it does the job for us currently.

OTOH, you might want to replace serialisation with serde soon anyway...

BR
Martin